### PR TITLE
Update restart-apache

### DIFF
--- a/mail/restart-apache
+++ b/mail/restart-apache
@@ -10,7 +10,7 @@ else
   cp -f /etc/letsencrypt/live/mail.cosmicexplorer.org/cert.pem /usr/local/apache2/conf/server.crt
   cp -f /etc/letsencrypt/live/mail.cosmicexplorer.org/privkey.pem /usr/local/apache2/conf/server.key
   cp -f /etc/letsencrypt/live/mail.cosmicexplorer.org/fullchain.pem /usr/local/apache2/conf/ca-chain.crt
-  apache2ctl graceful
+  apachectl graceful
 fi
 
 exit 0


### PR DESCRIPTION
the command apache2ctl is not actually valid for this docker image, rather it would just apachectl in this case.  I don't believe apache is actually restarting from within the container. 