### PR TITLE
Update docdb.sh

### DIFF
--- a/dcc/docdb.sh
+++ b/dcc/docdb.sh
@@ -109,5 +109,6 @@ fi
 sed -i -e "/db_rwpass/ s/Change.Me.too\!/${MYSQL_DOCDBRW_PASSWD}/;" /usr1/www/cgi-bin/private/DocDB/SiteConfig.pm
 sed -i -e "/db_ropass/ s/Change.Me.too\!/${MYSQL_DOCDBRO_PASSWD}/;" /usr1/www/cgi-bin/private/DocDB/SiteConfig.pm
 sed -i -e "/db_ropass/ s/Change.Me.too\!/${MYSQL_DOCDBRO_PASSWD}/;" /usr1/www/cgi-bin/DocDB/SiteConfig.pm
+sed -i "s/dcc.ligo.org/dcc.cosmicexplorer.org/g" /usr1/www/cgi-bin/DocDB/Search
 
 exit 0


### PR DESCRIPTION
This fixes the public google search to point to the cosmic explorer rather than ligo dcc. This is a monkey patch of a cgi-bin file from the docker image.